### PR TITLE
add getters for cur_pose and model_matrix

### DIFF
--- a/include/easy_pbr/Mesh.h
+++ b/include/easy_pbr/Mesh.h
@@ -214,6 +214,9 @@ public:
     void set_normals_tex(const cv::Mat& mat, const int subsample=1);
     bool is_any_texture_dirty();
 
+    Eigen::Affine3d get_cur_pose();
+    Eigen::Affine3d get_model_matrix();
+
 
     friend std::ostream &operator<<(std::ostream&, const Mesh& m);
 

--- a/src/Mesh.cxx
+++ b/src/Mesh.cxx
@@ -2100,6 +2100,14 @@ bool Mesh::is_any_texture_dirty(){
 
 }
 
+Eigen::Affine3d Mesh::get_cur_pose() {
+    return m_cur_pose;
+}
+
+Eigen::Affine3d Mesh::get_model_matrix() {
+    return m_model_matrix;
+}
+
 
 
 


### PR DESCRIPTION
These fields are now private but are used in another library. Therefore, I implemented these getters. Just let me know, whether further changes are required to correctly implement this.